### PR TITLE
Change institution identifier type from UUID to string

### DIFF
--- a/Models/event_institution.model.js
+++ b/Models/event_institution.model.js
@@ -14,7 +14,7 @@ const EventInstitution = sequelize.define("event_institutions", {
   },
 
   institution_id: {
-    type: DataTypes.UUID,
+    type: DataTypes.STRING,
     allowNull: false,
   }
 },

--- a/Models/ticket_institution.model.js
+++ b/Models/ticket_institution.model.js
@@ -14,7 +14,7 @@ const TicketInstitution = sequelize.define("ticket_institutions", {
   },
 
   institution_id: {
-    type: DataTypes.UUID,
+    type: DataTypes.STRING,
     allowNull: false,
   }
 },


### PR DESCRIPTION
This pull request updates the data type for the `institution_id` field in two models to improve compatibility or flexibility. The type is changed from `UUID` to `STRING` in both cases.

**Model updates:**

* Changed the `institution_id` field type from `DataTypes.UUID` to `DataTypes.STRING` in the `event_institutions` model (`Models/event_institution.model.js`).
* Changed the `institution_id` field type from `DataTypes.UUID` to `DataTypes.STRING` in the `ticket_institutions` model (`Models/ticket_institution.model.js`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated institution identifier storage configuration in backend systems to improve data handling consistency across event and ticket management features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->