### PR TITLE
Change routing key pattern for institution connection

### DIFF
--- a/Middleware/institution_connection.js
+++ b/Middleware/institution_connection.js
@@ -17,7 +17,7 @@ export async function consumeInstitutionEvents() {
   try {
     // 1. Connection Configuration
     const EXCHANGE_NAME = 'verisafe.events.topic';
-    const ROUTING_KEY_PATTERN = 'verisafe.institution.connection.*';
+    const ROUTING_KEY_PATTERN = 'user.institution.connection.*';
     const RABBITMQ_URL = `amqp://${RABBITMQ_USER}:${RABBITMQ_PASSWORD}@${RABBITMQ_HOST}:${RABBITMQ_PORT}${RABBITMQ_VHOST || '/'}`; // Update with your credentials
 
     const connection = await amqp.connect(RABBITMQ_URL);

--- a/Middleware/institution_connection.js
+++ b/Middleware/institution_connection.js
@@ -17,7 +17,7 @@ export async function consumeInstitutionEvents() {
   try {
     // 1. Connection Configuration
     const EXCHANGE_NAME = 'verisafe.events.topic';
-    const ROUTING_KEY_PATTERN = 'user.institution.connection.*';
+    const ROUTING_KEY_PATTERN = 'user.institution.*';
     const RABBITMQ_URL = `amqp://${RABBITMQ_USER}:${RABBITMQ_PASSWORD}@${RABBITMQ_HOST}:${RABBITMQ_PORT}${RABBITMQ_VHOST || '/'}`; // Update with your credentials
 
     const connection = await amqp.connect(RABBITMQ_URL);


### PR DESCRIPTION
This pull request updates the routing key pattern used for consuming institution connection events in the `consumeInstitutionEvents` function. The new pattern aligns with updated event naming conventions.

Event routing configuration:

* Changed the `ROUTING_KEY_PATTERN` from `'verisafe.institution.connection.*'` to `'user.institution.connection.*'` in `institution_connection.js` to match the new event routing scheme.