### PR TITLE
Fix push notification TTL validation error

### DIFF
--- a/Services/gossip_monger_push_notification.js
+++ b/Services/gossip_monger_push_notification.js
@@ -9,25 +9,25 @@ const RABBITMQ_USER = process.env.RABBITMQ_USER
 const RABBITMQ_VHOST = process.env.RABBITMQ_VHOST
 export async function sendPushNotification(notificationData, sourceServiceId, requestId = null) {
   const start = process.hrtime.bigint();
-  
+
   try {
     // Validation
     if (!sourceServiceId || !sourceServiceId.startsWith('io.opencrafts.')) {
       throw new Error('source_service_id must start with io.opencrafts.');
     }
-    
+
     if (!notificationData.headings || !notificationData.headings.en) {
       throw new Error('headings.en is required');
     }
-    
+
     if (!notificationData.contents || !notificationData.contents.en) {
       throw new Error('contents.en is required');
     }
-    
+
     if (!notificationData.target_user_id) {
       throw new Error('target_user_id is required');
     }
-    
+
     const targetingFields = [
       'included_segments',
       'excluded_segments',
@@ -42,20 +42,21 @@ export async function sendPushNotification(notificationData, sourceServiceId, re
       'include_windows_phone_reg_ids',
       'include_chrome_reg_ids'
     ];
-    
-    const hasTargeting = targetingFields.some(field => 
+
+    const hasTargeting = targetingFields.some(field =>
       notificationData[field] && notificationData[field].length > 0
     );
-    
+
     if (!hasTargeting) {
       throw new Error('At least one targeting field (included_segments, include_external_user_ids, etc.) is required');
     }
-    
-    // Validate ttl if provided
-    if (notificationData.ttl !== undefined && (notificationData.ttl < 1 || notificationData.ttl > 2592000)) {
-      throw new Error('ttl must be between 1 and 2,592,000 seconds (30 days)');
+
+    // Validate ttl if provided (safely ignoring null or undefined values)
+    if (notificationData.ttl !== undefined && notificationData.ttl !== null) {
+      if (notificationData.ttl < 1 || notificationData.ttl > 2592000) {
+        throw new Error('ttl must be between 1 and 2,592,000 seconds (30 days)');
+      }
     }
-    
     // Validate send_after if provided
     if (notificationData.send_after) {
       const sendAfterDate = new Date(notificationData.send_after);
@@ -66,50 +67,50 @@ export async function sendPushNotification(notificationData, sourceServiceId, re
         throw new Error('send_after must be a future date');
       }
     }
-    
+
     // Validate external user IDs count
     const externalUserIds = notificationData.include_external_user_ids || [];
     if (externalUserIds.length >= 2000) {
       throw new Error('Total external user IDs (including target_user_id) must not exceed 2,000');
     }
-    
+
     const EXCHANGE_NAME = 'gossip.topic.exchange';
     const ROUTING_KEY = 'gossip.push.send';
     const RABBITMQ_URL = `amqp://${RABBITMQ_USER}:${RABBITMQ_PASSWORD}@${RABBITMQ_HOST}:${RABBITMQ_PORT}${RABBITMQ_VHOST || '/'}`;
-    
+
     const connection = await amqp.connect(RABBITMQ_URL);
     const channel = await connection.createChannel();
-    
+
     await channel.assertExchange(EXCHANGE_NAME, 'topic', { durable: true });
-    
+
     // Generate request_id if not provided
     const finalRequestId = requestId || crypto.randomUUID();
-    
+
     // Build the notification object
     const notification = {
       headings: notificationData.headings,
       contents: notificationData.contents,
       target_user_id: notificationData.target_user_id
     };
-    
+
     // Add optional content fields
     const optionalFields = [
-      'subtitle', 'big_picture', 'large_icon', 'small_icon', 'data', 
-      'buttons', 'url', 'web_url', 'app_url', 'send_after', 
+      'subtitle', 'big_picture', 'large_icon', 'small_icon', 'data',
+      'buttons', 'url', 'web_url', 'app_url', 'send_after',
       'delayed_option', 'ttl', 'priority',
       'included_segments', 'excluded_segments', 'include_external_user_ids',
       'include_email_tokens', 'include_phone_numbers', 'include_ios_tokens',
       'include_android_reg_ids', 'include_chrome_web_reg_ids',
-      'include_firebase_reg_ids', 'include_amazon_reg_ids', 
+      'include_firebase_reg_ids', 'include_amazon_reg_ids',
       'include_windows_phone_reg_ids', 'include_chrome_reg_ids'
     ];
-    
+
     optionalFields.forEach(field => {
       if (notificationData[field] !== undefined && notificationData[field] !== null) {
         notification[field] = notificationData[field];
       }
     });
-    
+
     // Build the complete message
     const message = {
       metadata: {
@@ -120,24 +121,24 @@ export async function sendPushNotification(notificationData, sourceServiceId, re
       },
       notification: notification
     };
-    
+
     const published = channel.publish(
       EXCHANGE_NAME,
       ROUTING_KEY,
       Buffer.from(JSON.stringify(message)),
-      { 
+      {
         persistent: true,
         messageId: finalRequestId,
         timestamp: Math.floor(Date.now() / 1000)
       }
     );
-    
+
     await channel.close();
     await connection.close();
-    
+
     const end = process.hrtime.bigint();
     const durationMicroseconds = Number(end - start) / 1000;
-    
+
     logs(
       durationMicroseconds,
       "INFO",
@@ -148,13 +149,13 @@ export async function sendPushNotification(notificationData, sourceServiceId, re
       201,
       'push.send'
     );
-    
+
     return published;
-    
+
   } catch (error) {
     const end = process.hrtime.bigint();
     const durationMicroseconds = Number(end - start) / 1000;
-    
+
     logs(
       durationMicroseconds,
       "ERR",
@@ -166,7 +167,7 @@ export async function sendPushNotification(notificationData, sourceServiceId, re
       'push_publish_error',
       error.message
     );
-    
+
     console.error('[!] Error sending push notification:', error.message);
     throw error;
   }
@@ -186,7 +187,7 @@ export async function sendSegmentPushNotification({
   send_after = null,
   ttl = null
 }, sourceServiceId) {
-  
+
   return sendPushNotification({
     headings: typeof headings === 'string' ? { en: headings } : headings,
     contents: typeof contents === 'string' ? { en: contents } : contents,
@@ -213,14 +214,14 @@ export async function sendUserPushNotification({
   send_after = null,
   ttl = null
 }, sourceServiceId) {
-  
+
   // Ensure target_user_id is not duplicated in external_user_ids
   const externalIds = [...new Set([target_user_id, ...include_external_user_ids])];
-  
+
   if (externalIds.length > 2000) {
     throw new Error('Total external user IDs cannot exceed 2,000');
   }
-  
+
   return sendPushNotification({
     headings: typeof headings === 'string' ? { en: headings } : headings,
     contents: typeof contents === 'string' ? { en: contents } : contents,
@@ -247,18 +248,18 @@ export async function sendInteractivePushNotification({
   url = null,
   ttl = null
 }, sourceServiceId) {
-  
+
   if (!buttons || !buttons.length) {
     throw new Error('Buttons array is required for interactive notifications');
   }
-  
+
   // Validate buttons structure
   buttons.forEach((button, index) => {
     if (!button.id || !button.text) {
       throw new Error(`Button at index ${index} must have both id and text`);
     }
   });
-  
+
   return sendPushNotification({
     headings: typeof headings === 'string' ? { en: headings } : headings,
     contents: typeof contents === 'string' ? { en: contents } : contents,
@@ -281,16 +282,16 @@ export async function schedulePushNotification({
   data = null,
   delayed_option = 'timezone'
 }, sourceServiceId) {
-  
+
   if (!send_after) {
     throw new Error('send_after timestamp is required for scheduled notifications');
   }
-  
+
   const sendAfterDate = new Date(send_after);
   if (sendAfterDate <= new Date()) {
     throw new Error('send_after must be a future date');
   }
-  
+
   return sendPushNotification({
     headings: typeof headings === 'string' ? { en: headings } : headings,
     contents: typeof contents === 'string' ? { en: contents } : contents,


### PR DESCRIPTION
This pull request makes a small but important fix to the TTL (time-to-live) validation logic in the `sendPushNotification` function. The change ensures that `null` values for `ttl` are safely ignored, preventing potential errors when `ttl` is explicitly set to `null` rather than `undefined`.

- Validation logic improvement:
  * Updated the TTL validation in `sendPushNotification` (in `Services/gossip_monger_push_notification.js`) to safely ignore `null` values, only enforcing the range check when `ttl` is both defined and non-null.…,000 seconds (30 days)