### PR TITLE
Fix return statement to ensure only one value is returned

### DIFF
--- a/Repositories/Attendee.repository.js
+++ b/Repositories/Attendee.repository.js
@@ -311,7 +311,8 @@ export const getUserPurchasedTicketRepository = async (
   eventId
 ) => {
   try {
-    const attendees = await Attendee.findAll({
+    // 1. Changed findAll to findOne
+    const attendee = await Attendee.findOne({
       where: {
         user_id: userId,
         event_id: eventId
@@ -336,18 +337,19 @@ export const getUserPurchasedTicketRepository = async (
       ],
     });
 
-    // ✅ Normalize event_genre to always be an array
-    return attendees.map(attendee => {
-      const json = attendee.toJSON();
+    // If no record is found, return null safely
+    if (!attendee) return null;
 
-      if (json.event) {
-        json.event.event_genre = Array.isArray(json.event.event_genre)
-          ? json.event.event_genre
-          : JSON.parse(json.event.event_genre || "[]");
-      }
+    // 2. Normalize event_genre for the single object
+    const json = attendee.toJSON();
 
-      return json;
-    });
+    if (json.event) {
+      json.event.event_genre = Array.isArray(json.event.event_genre)
+        ? json.event.event_genre
+        : JSON.parse(json.event.event_genre || "[]");
+    }
+
+    return json;
 
   } catch (error) {
     throw error;


### PR DESCRIPTION
This pull request refactors the `getUserPurchasedTicketRepository` function in `Attendee.repository.js` to improve performance and simplify its behavior by returning a single attendee record instead of an array, and ensures safer handling when no record is found.

**Repository Query Changes:**
* Changed the query from `findAll` to `findOne` to return a single attendee record instead of an array, which is more appropriate for fetching a specific user's ticket for an event.

**Result Handling Improvements:**
* Added a check to return `null` if no attendee record is found, preventing errors when no matching record exists.
* Updated normalization logic for `event_genre` to operate on a single object instead of mapping over an array. [[1]](diffhunk://#diff-4aeacf7ea806e39261a9559bba9bbdf32272565cf31ce96796803f965f137af7L339-R343) [[2]](diffhunk://#diff-4aeacf7ea806e39261a9559bba9bbdf32272565cf31ce96796803f965f137af7L350)