### PR TITLE
Refactor getUserPurchasedTicketRepository function

### DIFF
--- a/Repositories/Attendee.repository.js
+++ b/Repositories/Attendee.repository.js
@@ -321,9 +321,9 @@ export const getAttendeesByEventIdRepository = async (eventId, limitPlusOne, off
   }
 }
 
-export const getUserPurchasedTicketRepository = async (userId, eventId) => {
+export const getUserPurchasedTicketsRepository = async (userId, eventId) => {
   try {
-    const attendeeInstance = await Attendee.findOne({
+    const attendeeInstances = await Attendee.findAll({
       where: {
         user_id: userId,
         event_id: eventId
@@ -348,31 +348,34 @@ export const getUserPurchasedTicketRepository = async (userId, eventId) => {
       ],
     });
 
-    // If no record is found, return null safely
-    if (!attendeeInstance) return null;
+    // If no records are found, return an empty array safely
+    if (!attendeeInstances || attendeeInstances.length === 0) return [];
 
-    // Convert Sequelize instance to a plain data object
-    const attendee = attendeeInstance.toJSON();
+    // 2. Map through the instances to convert to plain objects and parse genres
+    const attendees = attendeeInstances.map((instance) => {
+      const attendee = instance.toJSON();
 
-    // Safely parse event_genre if event exists
-    if (attendee.event) {
-      const genre = attendee.event.event_genre;
+      // Safely parse event_genre if event exists
+      if (attendee.event) {
+        const genre = attendee.event.event_genre;
 
-      if (Array.isArray(genre)) {
-        attendee.event.event_genre = genre;
-      } else if (typeof genre === "string") {
-        try {
-          const parsed = JSON.parse(genre || "[]");
-          attendee.event.event_genre = Array.isArray(parsed) ? parsed : [];
-        } catch {
+        if (Array.isArray(genre)) {
+          attendee.event.event_genre = genre;
+        } else if (typeof genre === "string") {
+          try {
+            attendee.event.event_genre = JSON.parse(genre || "[]");
+          } catch {
+            attendee.event.event_genre = [];
+          }
+        } else {
           attendee.event.event_genre = [];
         }
-      } else {
-        attendee.event.event_genre = [];
       }
-    }
 
-    return attendee;
+      return attendee;
+    });
+
+    return attendees;
 
   } catch (error) {
     throw error;

--- a/Repositories/Attendee.repository.js
+++ b/Repositories/Attendee.repository.js
@@ -363,7 +363,8 @@ export const getUserPurchasedTicketsRepository = async (userId, eventId) => {
           attendee.event.event_genre = genre;
         } else if (typeof genre === "string") {
           try {
-            attendee.event.event_genre = JSON.parse(genre || "[]");
+            const parsed = JSON.parse(genre || "[]");
+            attendee.event.event_genre = Array.isArray(parsed) ? parsed : [];
           } catch {
             attendee.event.event_genre = [];
           }

--- a/Repositories/Attendee.repository.js
+++ b/Repositories/Attendee.repository.js
@@ -381,3 +381,6 @@ export const getUserPurchasedTicketsRepository = async (userId, eventId) => {
     throw error;
   }
 };
+
+// Backwards-compatible alias (remove once all call sites are migrated)
+export const getUserPurchasedTicketRepository = getUserPurchasedTicketsRepository;


### PR DESCRIPTION
This pull request updates the logic for fetching user-purchased tickets in the `Attendee.repository.js` file to support returning multiple tickets instead of just one. The function is renamed and refactored to return an array of attendee records, improving consistency and handling of multiple purchases.

**Repository logic improvements:**

* Renamed `getUserPurchasedTicketRepository` to `getUserPurchasedTicketsRepository` and changed the implementation to use `findAll` instead of `findOne`, allowing retrieval of multiple attendee records for a given user and event.
* Updated the function to return an empty array when no records are found, instead of `null`.
* Refactored the code to map over all found attendee instances, converting each to a plain object and parsing the `event_genre` field as needed. [[1]](diffhunk://#diff-4aeacf7ea806e39261a9559bba9bbdf32272565cf31ce96796803f965f137af7L351-R356) [[2]](diffhunk://#diff-4aeacf7ea806e39261a9559bba9bbdf32272565cf31ce96796803f965f137af7L365-R366) [[3]](diffhunk://#diff-4aeacf7ea806e39261a9559bba9bbdf32272565cf31ce96796803f965f137af7R376-R378)