### PR TITLE
Prevent organizers from viewing private tickets and add versioning

### DIFF
--- a/Repositories/Ticket.repository.js
+++ b/Repositories/Ticket.repository.js
@@ -71,15 +71,6 @@ export const getTicketbyEventIdRepository = async (eventId, institutionIds = [],
       });
     }
 
-    // Check ownership via the Event table instead of the Ticket table
-    if (user_id) {
-      orConditions.push({
-        [Op.and]: [
-          { scope: "private" },
-          { '$event.organizer_id$': user_id } // Reaching into the joined Event model
-        ]
-      });
-    }
 
     const tickets = await Ticket.findAll({
       where: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sherehe",
-  "version": "1.0.0",
+  "version": "2.2.7",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This pull request includes a version update and a change to the ticket retrieval logic. The most important changes are:

Versioning:

* Updated the project version in `package.json` from `1.0.0` to `2.2.7`.

Ticket repository logic:

* Removed the code that checked for ticket ownership via the related `Event` table when fetching tickets in `getTicketbyEventIdRepository`, simplifying the query conditions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated ticket filtering and visibility logic for authenticated users. Adjusted criteria used when retrieving tickets through event-based queries; the set of accessible tickets may differ based on new filtering conditions.

* **Chores**
  * Version updated to 2.2.7

<!-- end of auto-generated comment: release notes by coderabbit.ai -->