### PR TITLE
Allow null values for country and state_province fields

### DIFF
--- a/Models/institution.model.js
+++ b/Models/institution.model.js
@@ -15,11 +15,11 @@ const Institution = sequelize.define(
     },
     country: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     state_province: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
   },
   {


### PR DESCRIPTION
This pull request makes a small change to the `Institution` model, updating the schema to allow `country` and `state_province` fields to be nullable. This means that records can now be created without requiring values for these fields.