### PR TITLE
Alter sequelize sync to update existing models

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ app.listen(PORT, async () => {
   try {
     await sequelize.authenticate();
 
-    await sequelize.sync({});
+    await sequelize.sync({alter:true});
     console.log("✅ Models synced...");
     // startVerisafeListener();
     await startMpesaSuccessConsumer();


### PR DESCRIPTION
This pull request makes a small change to the way the Sequelize models are synchronized with the database. The `sequelize.sync` call now uses the `alter: true` option, which allows Sequelize to automatically adjust the database schema to match the models without dropping tables.

* Changed `sequelize.sync({})` to `sequelize.sync({alter:true})` in `index.js` to enable automatic schema synchronization without data loss.