### PR TITLE
Change Sequelize sync option to force

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ app.listen(PORT, async () => {
   try {
     await sequelize.authenticate();
 
-    await sequelize.sync({alter:true});
+    await sequelize.sync({force:true});
     console.log("✅ Models synced...");
     // startVerisafeListener();
     await startMpesaSuccessConsumer();


### PR DESCRIPTION
This pull request makes a small change to the database synchronization logic in `index.js`. The change switches the Sequelize sync option from `alter:true` to `force:true`, which will drop and recreate all tables each time the server starts. This is a significant change for development or testing environments, as it resets the database schema and data on every run.